### PR TITLE
Remove Chumpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   'numpy-stl',
   'torchgeometry',
   'opencv-python',
-  'chumpy',
   'imageio',
   'gymnasium>=0.29.1',
   'hydra-core>=1.3',

--- a/requirement.txt
+++ b/requirement.txt
@@ -19,7 +19,6 @@ git+https://github.com/ZhengyiLuo/smplx.git@master
 lxml
 autograd
 scikit-learn
-chumpy
 patchelf
 wandb
 pyvirtualdisplay


### PR DESCRIPTION
- is this necessary? makes installation harder with newer build tools like uv and isn't used in the repo AFAICT